### PR TITLE
Test errors without .pep8speaks.yml

### DIFF
--- a/modules/good_module.py
+++ b/modules/good_module.py
@@ -13,7 +13,7 @@ import ping_me.authenticate
 def main() :
     """Executed by cron every minute. Sends POST request to recieve dsankdnsakdnkajsdnkjasdnkjasdnkjasndkjasndkjasndkjnasdkjsandkjandkjansdkjandkad
     reminder for upcoming minute."""
-
+    #### #### Too many leading #
     target = "http://ping-me.himanshumishra.in/ping/"
     email = ping_me.authenticate.extract_email()
     key = ping_me.authenticate.extract_password()

--- a/modules/good_module.py
+++ b/modules/good_module.py
@@ -11,7 +11,7 @@ from ping_me.utils import cryptex
 import ping_me.authenticate
 
 def main() :
-    """Executed by cron every minute. Sends POST request to recieve
+    """Executed by cron every minute. Sends POST request to recieve dsankdnsakdnkajsdnkjasdnkjasdnkjasndkjasndkjasndkjnasdkjsandkjandkjansdkjandkad
     reminder for upcoming minute."""
 
     target = "http://ping-me.himanshumishra.in/ping/"


### PR DESCRIPTION
This Pull Request introduces PEP 8 errors to a Python file. Errors should be reported here with the [default configuration](https://github.com/OrkoHunter/pep8speaks/blob/master/data/default_config.json).

To test a new deployment, delete the comment by `@pep8speaks`, close and then re-open Pull Request.

---

*Expected Result* -

---

Hello @OrkoHunter! Thanks for updating this PR. We checked the lines you've touched for [PEP 8](https://www.python.org/dev/peps/pep-0008) issues, and found:

* In the file [`modules/good_module.py`](https://github.com/OrkoHunter/test-pep8speaks/blob/7bd64e782f605d3a4f7388c0c993ebb344a952c4/modules/good_module.py):

> [Line 14:80](https://github.com/OrkoHunter/test-pep8speaks/blob/7bd64e782f605d3a4f7388c0c993ebb344a952c4/modules/good_module.py#L14): [E501](https://duckduckgo.com/?q=pep8%20E501) line too long (147 > 79 characters)
> [Line 16:5](https://github.com/OrkoHunter/test-pep8speaks/blob/7bd64e782f605d3a4f7388c0c993ebb344a952c4/modules/good_module.py#L16): [E266](https://duckduckgo.com/?q=pep8%20E266) too many leading '#' for block comment


---