### PR TITLE
Test errors with pep8speaks.yml

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,4 @@
+pycodestyle:
+    max-line-length: 81  # Default is 79 in PEP 8
+    ignore:  # Errors and warnings to ignore
+        - E266

--- a/modules/good_module.py
+++ b/modules/good_module.py
@@ -11,9 +11,11 @@ from ping_me.utils import cryptex
 import ping_me.authenticate
 
 def main() :
-    """Executed by cron every minute. Sends POST request to recieve
+    """Executed by cron every minute. Sends POST request to recieve let's make this line biggggggkgdalfknaklsnaldknaslkdnalksdnlaskdnlaksdnlaksdnlskdnlskadnlsakdnsladk
     reminder for upcoming minute."""
 
+    ###### Tooooo many ### To be ignored
+    
     target = "http://ping-me.himanshumishra.in/ping/"
     email = ping_me.authenticate.extract_email()
     key = ping_me.authenticate.extract_password()


### PR DESCRIPTION
This Pull Request introduces PEP 8 errors to a Python file. Errors should be reported here with the `.pep8speaks.yml` file present in this branch since the base branch does not contain any `.pep8speaks.yml`

To test a new deployment, delete the comment by @pep8speaks, close and then re-open Pull Request.

---

*Expected Result -*

---
Hello @OrkoHunter! Thanks for opening this PR. We checked the lines you've touched for [PEP 8](https://www.python.org/dev/peps/pep-0008) issues, and found:

* In the file [`modules/good_module.py`](https://github.com/OrkoHunter/test-pep8speaks/blob/076c6c107250b61f9bec84230e5c2aa63c337901/modules/good_module.py):

> [Line 14:82](https://github.com/OrkoHunter/test-pep8speaks/blob/076c6c107250b61f9bec84230e5c2aa63c337901/modules/good_module.py#L14): [E501](https://duckduckgo.com/?q=pep8%20E501) line too long (167 > 81 characters)
> [Line 18:1](https://github.com/OrkoHunter/test-pep8speaks/blob/076c6c107250b61f9bec84230e5c2aa63c337901/modules/good_module.py#L18): [W293](https://duckduckgo.com/?q=pep8%20W293) blank line contains whitespace

---