### PR TITLE
Testing new changes

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,2 @@
+scanner:
+    diff_only: false

--- a/modules/good_module.py
+++ b/modules/good_module.py
@@ -11,10 +11,12 @@ from ping_me.utils import cryptex
 import ping_me.authenticate
 
 def main() :
-    """Executed by cron every minute. Sends POST request to recieve
+    """Executed by cron every minute. Sends POST request to recieve dsadakjdkajndkjasndkjasndkjasndkjsandkjasndkjasndkjasdnkjasndkjasdnkjsandkjasdnkjadnkjadnda
     reminder for upcoming minute."""
-
-    target = "http://ping-me.himanshumishra.in/ping/"
+    
+    #### Tooo many ###
+    
+    target="http://ping-me.himanshumishra.in/ping/"
     email = ping_me.authenticate.extract_email()
     key = ping_me.authenticate.extract_password()
     data_t = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,24 @@
+
+# Comments
+# More comments
+
+[some_section]
+some_config = some_value  # Comments
+another_config = another_value
+
+[flake8]
+max-line-length = 81
+ignore =
+    W503,  # line break before binary operator
+    W504,  # line break after binary operator
+    E402,  # module level import not at top of file
+    E731,  # do not assign a lambda expression, use a def
+    C406,  # Unnecessary list literal - rewrite as a dict literal.
+    C408,  # Unnecessary dict call - rewrite as a literal.
+    C409,  # Unnecessary list passed to tuple() - rewrite as a tuple literal.
+    S001   # found modulo formatter (incorrect picks up mod operations)
+exclude =
+    doc/sphinxext/*.py,
+    .eggs/*.py,
+    versioneer.py,
+    env  # exclude asv benchmark environments from linting

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,0 +1,1 @@
+print("a long looooooong line dnsakdnsakjdnaskjdnkajsndkjasndkjasndkjasndkjasdnkasdnkjansdkjdnkjasdnkjasdnksjdnkjadnskjdnakjdnakdsjnaskjdnsakjdnksadnj")


### PR DESCRIPTION
Triggered out of Travis.

---
*Expected Result -*

---
Hello @OrkoHunter! Thanks for updating this PR. We checked the lines you've touched for [PEP 8](https://www.python.org/dev/peps/pep-0008) issues, and found:

* In the file [`modules/good_module.py`](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py):

> [Line 2:1](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py#L2): [E265](https://duckduckgo.com/?q=pep8%20E265) block comment should start with '# '
> [Line 13:1](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py#L13): [E302](https://duckduckgo.com/?q=pep8%20E302) expected 2 blank lines, found 1
> [Line 13:11](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py#L13): [E203](https://duckduckgo.com/?q=pep8%20E203) whitespace before ':'
> [Line 14:82](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py#L14): [E501](https://duckduckgo.com/?q=pep8%20E501) line too long (159 > 81 characters)
> [Line 16:1](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py#L16): [W293](https://duckduckgo.com/?q=pep8%20W293) blank line contains whitespace
> [Line 17:5](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py#L17): [E266](https://duckduckgo.com/?q=pep8%20E266) too many leading '#' for block comment
> [Line 18:1](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py#L18): [W293](https://duckduckgo.com/?q=pep8%20W293) blank line contains whitespace
> [Line 19:11](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py#L19): [E225](https://duckduckgo.com/?q=pep8%20E225) missing whitespace around operator
> [Line 40:1](https://github.com/OrkoHunter/test-pep8speaks/blob/d2dfbb72f2e72758bad016b682e5f9a5a38d5599/modules/good_module.py#L40): [E305](https://duckduckgo.com/?q=pep8%20E305) expected 2 blank lines after class or function definition, found 1


---